### PR TITLE
Fixed lists version check

### DIFF
--- a/Globals/tagger.gd
+++ b/Globals/tagger.gd
@@ -71,7 +71,7 @@ enum Notifications {
 
 
 var e6_headers_data: Dictionary = {
-	"User-Agent": "TaglistMaker/1.3.0 (by Ketei)",
+	"User-Agent": "TaglistMaker/1.3.1 (by Ketei)",
 }
 
 const valid_textures: Array[String] = ["jpg", "png", "gif"]

--- a/Resource/settings_lists.gd
+++ b/Resource/settings_lists.gd
@@ -548,14 +548,14 @@ extends Resource
 }
 
 @export var tag_types: Dictionary = {}
-@export var list_version: int = 1
+@export var list_version: int = 2
 
 static var current_version: int = 2
 
 static func load_database(lists_path: String) -> SettingLists:
 	if ResourceLoader.exists(lists_path, "SettingLists"):
 		var list_load: SettingLists = ResourceLoader.load(lists_path)
-		if list_load.list_version < current_version:
+		if list_load.list_version == 1:
 			list_load.list_version = current_version
 			var fixed_dict: Dictionary = {}
 			for key in list_load.tag_types.keys():
@@ -563,7 +563,9 @@ static func load_database(lists_path: String) -> SettingLists:
 			list_load.tag_types = fixed_dict.duplicate(true)
 		return list_load
 	else:
-		return SettingLists.new()
+		var _new_list: SettingLists = SettingLists.new()
+		_new_list.list_version = current_version
+		return _new_list
 
 
 func save() -> void:

--- a/Resource/tag_resource.gd
+++ b/Resource/tag_resource.gd
@@ -103,4 +103,3 @@ func get_tag_groups() -> Dictionary:
 					tag_groups[group]["tags"].erase(_tag)
 	return tag_groups
 
-

--- a/Scenes/application.tscn
+++ b/Scenes/application.tscn
@@ -3434,7 +3434,6 @@ visible = false
 layout_mode = 2
 
 [node name="Settings" type="Control" parent="." node_paths=PackedStringArray("aliases_vbox")]
-visible = false
 anchors_preset = 0
 offset_top = 56.0
 offset_right = 1280.0
@@ -3852,7 +3851,7 @@ alignment = 1
 modulate = Color(0, 0, 0, 0.392157)
 layout_mode = 2
 theme_override_font_sizes/font_size = 25
-text = "v 1.3.0"
+text = "v 1.3.1"
 horizontal_alignment = 1
 vertical_alignment = 1
 
@@ -4295,6 +4294,7 @@ access = 2
 script = ExtResource("32_3ueat")
 
 [node name="SplashScreenTexture" type="TextureRect" parent="."]
+visible = false
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0

--- a/Scripts/tagger_controls.gd
+++ b/Scripts/tagger_controls.gd
@@ -369,7 +369,6 @@ func add_new_tag(tag_name: String, add_from_signal: bool = true, search_online: 
 		append_registered_tag(tag_load, search_online)
 		var html_code: String = Tagger.settings.category_color_code[Tagger.Categories.keys()[tag_load.category]]
 		add_index = item_list.add_item(tag_name, load("res://Textures/valid_tag.png"))
-			
 		item_list.set_item_custom_fg_color(
 				add_index,
 				Color.html(html_code))


### PR DESCRIPTION
Fixed a bug that caused wrong structure on lists.tres. This bug occurred only on a second launch when using the latest version and you hadn't used the tagger prior to 1.3.0